### PR TITLE
Upgrade dependency eth-account to 0.4.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ install_requires = [
     "cytoolz>=0.9.0,<1.0.0;implementation_name=='cpython'",
 
     "eth-abi>=2.0.0b6,<3.0.0",
-    "eth-account>=0.2.1,<0.4.0",
+    "eth-account==0.4.0",
     "eth-utils>=1.3.0,<2.0.0",
     "eth-hash[pycryptodome]>=0.2.0,<1.0.0",
 


### PR DESCRIPTION
Version 0.4.0 does not have significant breaking changes, as seen in the [release notes](eth-account). Anyway python 3.5 is not supported for this project. The main reason for this change is that without it it'd conflict with [Web3](https://web3py.readthedocs.io/en/stable/), and I bet it's fairly common to see both Tron and Ethereum in the same project. At least that was my case in a backend. 

Since there are no tests at all I of course cannot guarantee nothing's going to break, but I've been testing it for a while and so far I did not encounter any issues. I hence leave the change here in case it can be considered for merging.